### PR TITLE
Display 0 comments if comments fail to load

### DIFF
--- a/src/components/post/post.js
+++ b/src/components/post/post.js
@@ -145,7 +145,7 @@ function Post({ postData }) {
             <p className="numComments">
               {postData.num_comments
                 ? postData.num_comments
-                : 'Number of comments failed to load'}{' '}
+                : '0'}{' '}
               comments
             </p>
           </NavLink>


### PR DESCRIPTION
Before if comments failed to load there was a very long error message that would overlap with the upvote count.

Closes issue #5 